### PR TITLE
Allow icon-only close button for snackbar

### DIFF
--- a/lib/Snackbar.vue
+++ b/lib/Snackbar.vue
@@ -63,9 +63,7 @@ const finalSnackbarProps = computed(() => {
         {{ text }}
       </template>
       <template v-if="showCloseButton" #actions>
-        <VBtn v-bind="closeButtonProps" variant="text" @click="snackbar = false">
-          {{ closeButtonText }}
-        </VBtn>
+        <VBtn variant="text" :text="closeButtonText" v-bind="closeButtonProps" @click="snackbar = false" />
       </template>
     </VSnackbar>
   </VThemeProvider>


### PR DESCRIPTION
This will fix #31.

#### Explanation of desired effect:

When the `icon` field of `closeButtonProps` is specified, the text for the close button will be ignored, only the icon is shown.

As a side note, I place `v-bind="closeButtonProps"` last, so fields in `closeButtonProps` can override `variant`, in case some users may want to change it -- and even `closeButtonText`.
